### PR TITLE
[iap] Change HTTP library to h2non/gentleman

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: go
 go:
   - 1.6
-  - 1.5
+  - 1.7
   - tip
 
 matrix:

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ go get github.com/evalphobia/go-iap/playstore
 ```go
 import(
 	"log"
-	
+
 	"github.com/evalphobia/go-iap/appstore"
 )
 
@@ -48,6 +48,8 @@ func buy() {
 	client := appstore.NewWithConfig(appstore.Config{
 		TimeOut:      30 * time.Second,
 		IsProduction: true,
+		Retry:        true,  // retry when HTTP error status
+		Debug:        false, // show HTTP request
 	})
 
 	// call apple store api to check receipt
@@ -90,7 +92,7 @@ func buy() {
 		log.Errof("cannot find valid in_app data by unknown error")
 		return
 	}
-	
+
 	// save iap data of valid receipt...
 }
 ```
@@ -100,7 +102,7 @@ func buy() {
 ```go
 import(
 	"log"
-	
+
 	"golang.org/x/oauth2"
 	"github.com/evalphobia/go-iap/playstore"
 )

--- a/appstore/request.go
+++ b/appstore/request.go
@@ -1,0 +1,113 @@
+package appstore
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http/httputil"
+	"time"
+
+	"gopkg.in/h2non/gentleman-retry.v1"
+	"gopkg.in/h2non/gentleman.v1"
+	"gopkg.in/h2non/gentleman.v1/context"
+	"gopkg.in/h2non/gentleman.v1/plugin"
+	"gopkg.in/h2non/gentleman.v1/plugins/body"
+	"gopkg.in/h2non/gentleman.v1/plugins/timeout"
+)
+
+// post sends POST request with option.
+func post(url string, opt option) (*response, error) {
+	opt.URL = url
+	return call(opt)
+}
+
+func call(opt option) (*response, error) {
+	cli := gentleman.New()
+	cli.URL(opt.URL)
+
+	req := cli.Request()
+	req.Method("POST")
+
+	// Set timeout
+	if opt.hasTimeout() {
+		req.Use(timeout.Request(opt.Timeout))
+	}
+	// Set retry (3 times)
+	if opt.Retry {
+		req.Use(retry.New(retry.ConstantBackoff))
+	}
+	// Set POST parameter
+	if opt.hasPayload() {
+		req.Use(body.JSON(opt.Payload))
+	}
+
+	// show debug request
+	if opt.Debug {
+		req.Use(debugRequest())
+	}
+
+	resp, err := req.Send()
+	if opt.Debug {
+		showDebugResponse(resp, err)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return &response{resp}, nil
+}
+
+// option is wrapper struct of http option
+type option struct {
+	URL     string
+	Timeout time.Duration
+	Retry   bool
+	Debug   bool
+
+	// POST Parameter
+	Payload interface{}
+}
+
+func (o option) hasTimeout() bool {
+	return o.Timeout > 0
+}
+
+func (o option) hasPayload() bool {
+	return o.Payload != nil
+}
+
+// response is wrapper struct pf *gentleman.Response
+type response struct {
+	*gentleman.Response
+}
+
+func debugRequest() plugin.Plugin {
+	p := plugin.New()
+	p.SetHandler("before dial", func(ctx *context.Context, h context.Handler) {
+		req := ctx.Request
+		body, _ := ioutil.ReadAll(req.Body)
+		req.Body = ioutil.NopCloser(bytes.NewReader(body))
+		dump, _ := httputil.DumpRequest(req, false)
+
+		fmt.Printf("---> [HTTP Request] %s[Request Body]\n%s\n", string(dump), body)
+		h.Next(ctx)
+	})
+	return p
+}
+
+func showDebugResponse(resp *gentleman.Response, err error) {
+	if err, ok := err.(net.Error); ok && err.Timeout() {
+		fmt.Printf("<--- [HTTP Response ] timeout\n\n")
+		return
+	}
+	if resp == nil {
+		return
+	}
+
+	res := resp.RawResponse
+	body, _ := ioutil.ReadAll(res.Body)
+	res.Body = ioutil.NopCloser(bytes.NewReader(body))
+	dump, _ := httputil.DumpResponse(res, false)
+
+	fmt.Printf("<--- [HTTP Response] %s[Response Body]\n%s\n", string(dump), body)
+}

--- a/appstore/request.go
+++ b/appstore/request.go
@@ -76,7 +76,7 @@ func (o option) hasPayload() bool {
 	return o.Payload != nil
 }
 
-// response is wrapper struct pf *gentleman.Response
+// response is wrapper struct of *gentleman.Response
 type response struct {
 	*gentleman.Response
 }

--- a/appstore/validator_test.go
+++ b/appstore/validator_test.go
@@ -3,6 +3,7 @@ package appstore
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -170,10 +171,15 @@ func TestVerifyTimeout(t *testing.T) {
 		ReceiptData: "dummy data",
 	}
 
-	expected := errors.New("")
 	_, actual := client.Verify(req)
-	if !reflect.DeepEqual(reflect.TypeOf(actual), reflect.TypeOf(expected)) {
+	netErr, ok := actual.(net.Error)
+	if !ok {
+		var expected net.Error
 		t.Errorf("got %v\nwant %v", actual, expected)
+		return
+	}
+	if !netErr.Timeout() {
+		t.Errorf("got %v\n, want Timeout() is true", netErr)
 	}
 }
 


### PR DESCRIPTION
Change HTTP request library to h2non/gentleman for appstore;

- Return original HTTP error (incl. timeout)
- Add Config.Retry field to retry HTTP call when HTTP error
- Add Config.Debug field to debug and show HTTP req/resp
