### PR TITLE
Add pending_renewal_info key to ios7 response

### DIFF
--- a/appstore/converter.go
+++ b/appstore/converter.go
@@ -53,3 +53,22 @@ func ToTime(msString string) time.Time {
 	}
 	return time.Unix(int64(ms/1000), 0)
 }
+
+func ToReceiptPendingRenewalInfos(pris []PendingRenewalInfo) ReceiptPendingRenewalInfos {
+	var rpris ReceiptPendingRenewalInfos
+	for _, pri := range pris {
+		rpris = append(rpris, ToReceiptPendingRenewalInfo(pri))
+	}
+	return rpris
+}
+
+func ToReceiptPendingRenewalInfo(pri PendingRenewalInfo) *ReceiptPendingRenewalInfo {
+	return &ReceiptPendingRenewalInfo{
+		ExpirationIntent:   ToInt64(pri.ExpirationIntent),
+		AutoRenewProductID: pri.AutoRenewProductID,
+		RetryFlag:          ToBool(pri.RetryFlag),
+		AutoRenewStatus:    ToBool(pri.AutoRenewStatus),
+		PriceConsentStatus: ToBool(pri.PriceConsentStatus),
+		ProductID:          pri.ProductID,
+	}
+}

--- a/appstore/model_ios7.go
+++ b/appstore/model_ios7.go
@@ -4,13 +4,14 @@ const verIOS7 = 7
 
 // The IAPResponse type has the response properties
 type IAPResponseIOS7 struct {
-	responseVersion   int         `json:"-"`
-	rawReceipt        string      `json:"-"`
-	Status            int         `json:"status"`
-	Environment       string      `json:"environment"`
-	Receipt           ReceiptIOS7 `json:"receipt"`
-	LatestReceiptInfo []InApp     `json:"latest_receipt_info"`
-	LatestReceipt     string      `json:"latest_receipt"`
+	responseVersion    int                  `json:"-"`
+	rawReceipt         string               `json:"-"`
+	Status             int                  `json:"status"`
+	Environment        string               `json:"environment"`
+	Receipt            ReceiptIOS7          `json:"receipt"`
+	LatestReceiptInfo  []InApp              `json:"latest_receipt_info"`
+	LatestReceipt      string               `json:"latest_receipt"`
+	PendingRenewalInfo []PendingRenewalInfo `json:"pending_renewal_info"`
 }
 
 func NewIAPResponseIOS7(rc string) *IAPResponseIOS7 {
@@ -37,6 +38,7 @@ func (r *IAPResponseIOS7) ToReceipt() *Receipt {
 	}
 	receipt.InApps = ToReceiptInApps(rr.InApp)
 	receipt.LatestReceiptInfo = ToReceiptInApps(r.LatestReceiptInfo)
+	receipt.PendingRenewalInfo = ToReceiptPendingRenewalInfos(r.PendingRenewalInfo)
 	return receipt
 }
 
@@ -68,4 +70,14 @@ type InApp struct {
 	OriginalPurchaseDate
 	ExpiresDate
 	CancellationDate
+}
+
+// PendingRenewalInfo auto-renewable subscriptions
+type PendingRenewalInfo struct {
+	ExpirationIntent   string `json:"expiration_intent"`
+	AutoRenewProductID string `json:"auto_renew_product_id"`
+	RetryFlag          string `json:"is_in_billing_retry_period"`
+	AutoRenewStatus    string `json:"auto_renew_status"`
+	PriceConsentStatus string `json:"price_consent_status"`
+	ProductID          string `json:"product_id"`
 }

--- a/appstore/receipt.go
+++ b/appstore/receipt.go
@@ -24,6 +24,8 @@ type Receipt struct {
 
 	LatestReceiptInfo ReceiptInApps
 	LatestReceipt     string
+
+	PendingRenewalInfo ReceiptPendingRenewalInfos
 }
 
 func (r *Receipt) String() string {

--- a/appstore/receipt_data_test.go
+++ b/appstore/receipt_data_test.go
@@ -8475,7 +8475,16 @@ var testReceiptString = `{
       "is_trial_period": "false"
     }
   ],
-  "latest_receipt": "<latest receipt string>"
+  "latest_receipt": "<latest receipt string>",
+  "pending_renewal_info": [
+    {
+      "auto_renew_product_id": "com.example.app.subscription_1",
+      "auto_renew_status": "1",
+      "expiration_intent": "0",
+      "is_in_billing_retry_period": "1",
+      "product_id": "com.example.app.subscription_1"
+    }
+  ]
 }`
 
 var testReceiptString2 = `{

--- a/appstore/receipt_pending_renewal_info.go
+++ b/appstore/receipt_pending_renewal_info.go
@@ -1,0 +1,22 @@
+package appstore
+
+// ReceiptPendingRenewalInfo is struct for pending_renewal_info field
+type ReceiptPendingRenewalInfo struct {
+	ExpirationIntent   int64  `json:"expiration_intent"`
+	AutoRenewProductID string `json:"auto_renew_product_id"`
+	RetryFlag          bool   `json:"is_in_billing_retry_period"`
+	AutoRenewStatus    bool   `json:"auto_renew_status"`
+	PriceConsentStatus bool   `json:"price_consent_status"`
+	ProductID          string `json:"product_id"`
+}
+
+type ReceiptPendingRenewalInfos []*ReceiptPendingRenewalInfo
+
+func (r ReceiptPendingRenewalInfos) IsAutoRenewable(productID string) bool {
+	for _, v := range r {
+		if v.ProductID == productID {
+			return v.AutoRenewStatus
+		}
+	}
+	return false
+}

--- a/appstore/receipt_test.go
+++ b/appstore/receipt_test.go
@@ -343,3 +343,23 @@ func TestGetTransactionIDsByProductWithoutExpired(t *testing.T) {
 		}
 	}
 }
+
+func TestReceiptPendingRenewalInfoIsAutoRenewable(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		receipt   *Receipt
+		productID string
+		expected  bool
+	}{
+		{testReceipt1, "com.example.app.subscription_1", true},
+		{testReceipt1, "com.example.app.subscription_2", false},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(
+			tt.expected,
+			tt.receipt.PendingRenewalInfo.IsAutoRenewable(tt.productID),
+		)
+	}
+}


### PR DESCRIPTION
## JP doc

https://developer.apple.com/jp/documentation/General/ValidateAppStoreReceipt/Chapters/ReceiptFields.html#//apple_ref/doc/uid/TP40010573-CH106-SW29

## En ValidateReceipt doc

https://developer.apple.com/library/content/releasenotes/General/ValidateAppStoreReceipt/Chapters/ValidateRemotely.html

## Difference ProductID and AutoRenewProductID

https://forums.developer.apple.com/thread/82850