### PR TITLE
[appstore] Add function for status 21007

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: go
 go:
-  - 1.6
-  - 1.7
+  - 1.9.x
+  - 1.10.x
   - tip
 
 matrix:

--- a/appstore/receipt.go
+++ b/appstore/receipt.go
@@ -77,6 +77,11 @@ func (r *Receipt) HasExpired() bool {
 	return r.Status == 21006
 }
 
+// ShouldSendToTestEnvironment checks this receipt is from the test environment, but it was sent to the production environment for verification
+func (r *Receipt) ShouldSendToTestEnvironment() bool {
+	return r.Status == 21007
+}
+
 // GetTransactionIDs returns all of transaction_id from `in_app`
 func (r *Receipt) GetTransactionIDs() []int64 {
 	return r.InApps.TransactionIDs()

--- a/appstore/receipt.go
+++ b/appstore/receipt.go
@@ -77,9 +77,16 @@ func (r *Receipt) HasExpired() bool {
 	return r.Status == 21006
 }
 
-// ShouldSendToTestEnvironment checks this receipt is from the test environment, but it was sent to the production environment for verification
+// ShouldSendToTestEnvironment checks this receipt status is 21007
+// this receipt is from the test environment, but it was sent to the production environment for verification
 func (r *Receipt) ShouldSendToTestEnvironment() bool {
 	return r.Status == 21007
+}
+
+// ShouldSendToProductionEnvironment checks this receipt status is 21008
+// this receipt is from the production environment, but it was sent to the test environment for verification
+func (r *Receipt) ShouldSendToProductionEnvironment() bool {
+	return r.Status == 21008
 }
 
 // GetTransactionIDs returns all of transaction_id from `in_app`

--- a/appstore/receipt_test.go
+++ b/appstore/receipt_test.go
@@ -179,6 +179,54 @@ func TestHasExpired(t *testing.T) {
 	}
 }
 
+func TestShouldSendToTestEnvironment(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		status   int
+		expected bool
+	}{
+		{21000, false},
+		{21001, false},
+		{21002, false},
+		{21003, false},
+		{21004, false},
+		{21005, false},
+		{21006, false},
+		{21007, true},
+		{21008, false},
+	}
+
+	for _, tt := range tests {
+		receipt := Receipt{Status: tt.status}
+		assert.Equal(tt.expected, receipt.ShouldSendToTestEnvironment())
+	}
+}
+
+func TestShouldSendToProductionEnvironment(t *testing.T) {
+	assert := assert.New(t)
+
+	tests := []struct {
+		status   int
+		expected bool
+	}{
+		{21000, false},
+		{21001, false},
+		{21002, false},
+		{21003, false},
+		{21004, false},
+		{21005, false},
+		{21006, false},
+		{21007, false},
+		{21008, true},
+	}
+
+	for _, tt := range tests {
+		receipt := Receipt{Status: tt.status}
+		assert.Equal(tt.expected, receipt.ShouldSendToProductionEnvironment())
+	}
+}
+
 func TestGetTransactionIDs(t *testing.T) {
 	assert := assert.New(t)
 


### PR DESCRIPTION
I want a special method to determine the status 21007

Reference: Best practices below

# Always verify your receipt with the production URL first

```
If you are doing receipt validation, be sure to verify your receipt with the production URL (https://buy.itunes.apple.com/verifyReceipt) first. This applies even in the case where your app is used in the sandbox environment. App Review will review the production version of your app in the sandbox. When your app processes the receipt, it must be capable of detecting the 21007 receipt status code and sending the receipt to the sandbox receipt validation server (https://sandbox.itunes.apple.com/verifyReceipt). Once your app is approved and running in the production environment, sending the receipt to the production server first is the correct action. See What url should I use to verify my receipt? for more information.
```

https://developer.apple.com/library/archive/technotes/tn2387/_index.html